### PR TITLE
✨ Allow Workflow Run on Forks

### DIFF
--- a/.github/workflows/run-workflow-tests.yml
+++ b/.github/workflows/run-workflow-tests.yml
@@ -1,6 +1,10 @@
 name: Run Xircuits Workflows Test
 
 on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: "*"
   workflow_dispatch:
 
 jobs:
@@ -33,7 +37,14 @@ jobs:
       run: xircuits list 
 
     - name: Clone Repository
-      run: git clone -b ${{ env.BRANCH_NAME }} https://github.com/${{ github.repository }} ${{ env.COMPONENT_LIBRARY_PATH }}
+      run: |
+        rm -rf ${{ env.COMPONENT_LIBRARY_PATH }}
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          REPO_URL="${{ github.event.pull_request.head.repo.clone_url }}"
+        else
+          REPO_URL="https://github.com/${{ github.repository }}"
+        fi
+        git clone -b ${{ env.BRANCH_NAME }} $REPO_URL ${{ env.COMPONENT_LIBRARY_PATH }}
 
     - name: Install Component Library
       run: |

--- a/.github/workflows/run-workflow-tests.yml
+++ b/.github/workflows/run-workflow-tests.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Upload log file
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.LIBRARY_NAME }}-validation-workflow
         path: ${{ github.workspace }}/workflow_logs.txt


### PR DESCRIPTION
# Description

This PR allows the xircuits workflow validation github action to work with forks.

## Pull Request Type

- [ ] Xircuits Component Library Code
- [ ] Workflow Example
- [ ] Documentation
- [x] Others (Please Specify)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

**1. Workflow Test from Fork**

    1. Make a fork of a component library with this github action. Verify it runs.

## Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  
